### PR TITLE
OSh/fixed wrong HTTP code and text message

### DIFF
--- a/app/Exceptions/Handler.php
+++ b/app/Exceptions/Handler.php
@@ -66,7 +66,7 @@ class Handler extends ExceptionHandler
         }
 
         if ($e instanceof NotFoundHttpException){
-            return response(404);
+            return response('Resource not found', 404);
         }
 
         return parent::render($request, $e);


### PR DESCRIPTION
Now returns text string and 404 HTTP code, when route does not exist, instead the 404 string and 200 HTTP code.
